### PR TITLE
할 일 완료 API 구현

### DIFF
--- a/src/main/java/com/sparta/todo/controller/ToDoController.java
+++ b/src/main/java/com/sparta/todo/controller/ToDoController.java
@@ -155,4 +155,69 @@ public class ToDoController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "할 일 완료", description = "할 일 완료 API")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "할 일 완료 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "완료할 할 일이 없는 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "할 일에 대해 완료 권한이 없는 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "할 일이 이미 완료처리된 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+    })
+    @PostMapping("/{toDoId}/complete")
+    public ResponseEntity<Object> completeToDo(
+            @Parameter(description = "할 일 ID")
+            @PathVariable(value = "toDoId") Long toDoId,
+            @CurrentMember MemberDto memberDto
+    ) {
+        toDoService.completeToDo(toDoId, memberDto);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "할 일 완료 취소", description = "할 일 완료 취소 API")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "할 일 완료 취소 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "완료 취소할 할 일이 없는 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "할 일에 대해 완료 취소 권한이 없는 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "할 일이 완료되어있지 않은 경우",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+    })
+    @DeleteMapping("/{toDoId}/complete")
+    public ResponseEntity<Object> deleteCompleteToDo(
+            @Parameter(description = "할 일 ID")
+            @PathVariable(value = "toDoId") Long toDoId,
+            @CurrentMember MemberDto memberDto
+    ) {
+        toDoService.deleteCompleteToDo(toDoId, memberDto);
+
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/sparta/todo/domain/ToDo.java
+++ b/src/main/java/com/sparta/todo/domain/ToDo.java
@@ -24,7 +24,7 @@ public class ToDo extends BaseEntity{
 
     @ColumnDefault("false")
     @Column(name = "is_done", nullable = false)
-    private Boolean isDone = false;
+    private boolean isDone = false;
 
     @JoinColumn(name = "member_id")
     @ManyToOne(optional = false)  //optional: 외래키 not null 제약조건
@@ -53,5 +53,9 @@ public class ToDo extends BaseEntity{
     public void update(UpdateToDoRequest request) {
         this.title = request.title();
         this.content = request.content();
+    }
+
+    public void complete(boolean isDone) {
+        this.isDone = isDone;
     }
 }

--- a/src/main/java/com/sparta/todo/dto/response/ToDoResponse.java
+++ b/src/main/java/com/sparta/todo/dto/response/ToDoResponse.java
@@ -1,10 +1,13 @@
 package com.sparta.todo.dto.response;
 
 import com.sparta.todo.domain.ToDo;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public record ToDoResponse(
         @Schema(
@@ -31,12 +34,24 @@ public record ToDoResponse(
                 example = "username1"
         )
         String username,
+
+        @ArraySchema(schema = @Schema(implementation = CommentResponse.class))
+        Set<CommentResponse> comments,
+
+        @Schema(
+                description = "완료여부",
+                nullable = false,
+                example = "false",
+                allowableValues = {"true", "false"}
+        )
+        Boolean isDone,
         @Schema(
                 description = "작성일",
                 nullable = false,
                 example = "2023-11-18T01:26:23.982168"
         )
         LocalDateTime createdDateTime
+
 ) {
     @Builder
     public ToDoResponse {

--- a/src/main/java/com/sparta/todo/exception/AlreadyCompleteToDoException.java
+++ b/src/main/java/com/sparta/todo/exception/AlreadyCompleteToDoException.java
@@ -1,0 +1,8 @@
+package com.sparta.todo.exception;
+
+public class AlreadyCompleteToDoException extends ApiException {
+    public AlreadyCompleteToDoException() {
+
+        super(ErrorCode.ALREADY_COMPLETE_TO_DO);
+    }
+}

--- a/src/main/java/com/sparta/todo/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/todo/exception/ErrorCode.java
@@ -27,9 +27,11 @@ public enum ErrorCode {
     VALUE_NOT_FOUND(NOT_FOUND, "요청한 값을 찾을 수 없습니다."),
     TO_DO_NOT_FOUND(NOT_FOUND, "할 일을 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(NOT_FOUND, "댓글을 찾을 수 없습니다."),
+    TO_DO_COMPLETE_NOT_FOUND(NOT_FOUND, "할 일이 완료처리 되어있지 않습니다."),
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
     DUPLICATE_RESOURCE(CONFLICT, "데이터가 이미 존재합니다"),
+    ALREADY_COMPLETE_TO_DO(CONFLICT, "이미 완료 처리된 할 일입니다."),
     ALREADY_EXIST_MEMBER(CONFLICT, "이미 존재하는 회원입니다."),
 
 

--- a/src/main/java/com/sparta/todo/exception/NotCompleteToDoException.java
+++ b/src/main/java/com/sparta/todo/exception/NotCompleteToDoException.java
@@ -1,0 +1,8 @@
+package com.sparta.todo.exception;
+
+public class NotCompleteToDoException extends ApiException {
+
+    public NotCompleteToDoException() {
+        super(ErrorCode.TO_DO_COMPLETE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/sparta/todo/service/ToDoService.java
+++ b/src/main/java/com/sparta/todo/service/ToDoService.java
@@ -7,7 +7,9 @@ import com.sparta.todo.dto.request.CreateToDoRequest;
 import com.sparta.todo.dto.request.SearchToDoCondition;
 import com.sparta.todo.dto.request.UpdateToDoRequest;
 import com.sparta.todo.dto.response.ToDoResponse;
+import com.sparta.todo.exception.AlreadyCompleteToDoException;
 import com.sparta.todo.exception.MemberNotFoundException;
+import com.sparta.todo.exception.NotCompleteToDoException;
 import com.sparta.todo.exception.ToDoNotFoundException;
 import com.sparta.todo.repository.MemberRepository;
 import com.sparta.todo.repository.ToDoRepository;
@@ -75,5 +77,30 @@ public class ToDoService {
 
         checkMember(toDo.getMember().getId(), memberDto.id(), ACCESS_DENIED_MESSAGE);
         toDoRepository.delete(toDo);
+    }
+
+    public void completeToDo(Long toDoId, MemberDto memberDto) {
+        ToDo toDo = toDoRepository.findById(toDoId)
+                .orElseThrow(ToDoNotFoundException::new);
+
+        checkMember(toDo.getMember().getId(), memberDto.id(), ACCESS_DENIED_MESSAGE);
+
+        if (toDo.isDone()) {
+            throw new AlreadyCompleteToDoException();
+        }
+        toDo.complete(true);
+    }
+
+    public void deleteCompleteToDo(Long toDoId, MemberDto memberDto) {
+        ToDo toDo = toDoRepository.findById(toDoId)
+                .orElseThrow(ToDoNotFoundException::new);
+
+        checkMember(toDo.getMember().getId(), memberDto.id(), ACCESS_DENIED_MESSAGE);
+
+        if (!toDo.isDone()) {
+            throw new NotCompleteToDoException();
+        }
+
+        toDo.complete(false);
     }
 }


### PR DESCRIPTION
할 일 완료 API 를 구현하면서
고민했던 점이 하나의 API호출로 완료, 취소 상태를 검증하고 업데이트를 하는식으로
구현할까 했지만
REST의 원칙중하나가 자원과 자원의 대한 행위 표현을 제 나름대로 생각한 결과
완료, 완료취소에 대한 행위에 맞는 API 따로 구현하였습니다.